### PR TITLE
Added MANAGE_DISCOVERY authority to tuoni role

### DIFF
--- a/nova/core/galaxy.yml
+++ b/nova/core/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: nova
 name: core
-version: 3.18.3
+version: 3.18.4
 readme: README.md
 authors:
   - https://github.com/novateams

--- a/nova/core/roles/tuoni/defaults/main.yml
+++ b/nova/core/roles/tuoni/defaults/main.yml
@@ -20,6 +20,7 @@ tuoni_users: # The list of users that will be created in Tuoni pass a custom lis
       - MANAGE_LISTENERS
       - MANAGE_PAYLOADS
       - MANAGE_USERS
+      - MANAGE_DISCOVERY
       - MODIFY_FILES
       - SEND_COMMANDS
       - VIEW_RESOURCES # this default permission, cannot be removed


### PR DESCRIPTION
This option was introduced in tuoni v 0.8.0. Allows to create/edit/archive:
- hosts
- services
- credentials